### PR TITLE
Add polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Switchboard works by monitoring a directory you provide (or list of directories)
 
 See the video below as example. Here, I give switchboard a path to watch, a destination where I want matched files to move to, and the file extension of the type of files I want to move.
 
-[![asciicast](https://asciinema.org/a/cWSUfcUCU4Wd5rQEs5Detf7gn.svg)](https://asciinema.org/a/cWSUfcUCU4Wd5rQEs5Detf7gn)
+[![asciicast](https://asciinema.org/a/OwbnYltbn0jcSAGzfdmujwklJ.svg)](https://asciinema.org/a/OwbnYltbn0jcSAGzfdmujwklJ)
 
 ### Installation
 
@@ -60,6 +60,7 @@ Flags:
   -e, --ext string           File type you want to watch for.
   -h, --help                 help for watch
   -p, --path string          Path you want to watch.
+      --poll int             Specify a polling time in seconds. (default 3)
 ```
 
 To get started quickly, you can run the following command, passing in the path, destination, and file extenstion you want to watch for. See the example below.

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -67,11 +67,13 @@ func initCmd(runCmd cobra.Command) {
 	runCmd.PersistentFlags().StringP("path", "p", "", "Path you want to watch.")
 	runCmd.PersistentFlags().StringP("destination", "d", "", "Path you want files to be relocated.")
 	runCmd.PersistentFlags().StringP("ext", "e", "", "File type you want to watch for.")
+	runCmd.PersistentFlags().IntP("poll", "", 3, "Specify a polling time in seconds.")
 	runCmd.PersistentFlags().StringVar(&configFile, "config", "", "Pass an optional config file containing multiple paths to watch.")
 
 	viper.BindPFlag("path", runCmd.PersistentFlags().Lookup("path"))
 	viper.BindPFlag("destination", runCmd.PersistentFlags().Lookup("destination"))
 	viper.BindPFlag("ext", runCmd.PersistentFlags().Lookup("ext"))
+	viper.BindPFlag("poll", runCmd.PersistentFlags().Lookup("poll"))
 
 	var rootCmd = &cobra.Command{}
 	rootCmd.AddCommand(&runCmd)
@@ -139,7 +141,7 @@ func registerMultiConsumers() {
 	}
 
 	log.Println("Observing")
-	pw.Observe()
+	pw.Observe(viper.GetInt("poll"))
 }
 
 func registerSingleConsumer() {
@@ -156,5 +158,5 @@ func registerSingleConsumer() {
 	pw.Register(&pc)
 
 	log.Println("Observing")
-	pw.Observe()
+	pw.Observe(viper.GetInt("poll"))
 }

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -38,7 +38,7 @@ type Watcher struct {
 	// Ext is the file extention you want to watch for
 	Ext string `yaml:"ext"`
 	// Operation is the event operation you want to watch for
-	// CREATE, MODIFY, REMOVE, CHMOD etc.
+	// CREATE, MODIFY, REMOVE, CHMOD, WRITE itc.
 	Operation string `yaml:"operation"`
 }
 

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -154,5 +154,7 @@ func registerSingleConsumer() {
 	}
 
 	pw.Register(&pc)
+
+	log.Println("Observing")
 	pw.Observe()
 }

--- a/event/event.go
+++ b/event/event.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/cian911/switchboard/utils"
 )
@@ -22,6 +23,8 @@ type Event struct {
 	Operation string
 	// IsDir is the new create vent a directory
 	IsDir bool
+	// Timestamp in unix time epoch
+	Timestamp int64
 }
 
 // New creates and returns a new event struct
@@ -31,6 +34,7 @@ func New(file, path, dest, ext string) *Event {
 		Path:        path,
 		Destination: dest,
 		Ext:         ext,
+		Timestamp:   time.Now().Unix(),
 	}
 }
 

--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,7 @@ type Event struct {
 	// IsDir is the new create vent a directory
 	IsDir bool
 	// Timestamp in unix time epoch
-	Timestamp int64
+	Timestamp time.Time
 }
 
 // New creates and returns a new event struct
@@ -34,7 +34,7 @@ func New(file, path, dest, ext string) *Event {
 		Path:        path,
 		Destination: dest,
 		Ext:         ext,
-		Timestamp:   time.Now().Unix(),
+		Timestamp:   time.Now(),
 	}
 }
 
@@ -48,7 +48,7 @@ func (e *Event) Move(path, file string) error {
 
 // IsValidEvent checks if the event operation and file extension is valid
 func (e *Event) IsValidEvent(ext string) bool {
-	if ext == e.Ext && e.Operation == "CREATE" {
+	if ext == e.Ext && e.Operation == "CREATE" || e.Operation == "WRITE" {
 		return true
 	}
 

--- a/watcher/poller.go
+++ b/watcher/poller.go
@@ -1,12 +1,25 @@
 package watcher
 
-import "time"
+import (
+	"log"
+	"time"
+)
 
-func Poll(interval int) {
-	ticker := time.NewTicker(interval * time.Second)
+// Poll polls the queue for valid events given an interval (in seconds)
+func (pw *PathWatcher) Poll(interval int) {
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	for {
 		select {
 		case <-ticker.C:
+			log.Printf("Polling... - Queue Size: %d\n", pw.Queue.Size())
+
+			for hsh, ev := range pw.Queue.Queue {
+				timeDiff := ev.Timestamp.Sub(time.Now())
+				if timeDiff < (time.Duration(-interval) * time.Second) {
+					pw.Notify(ev.Path, ev.Operation)
+					pw.Queue.Remove(hsh)
+				}
+			}
 		}
 	}
 }

--- a/watcher/poller.go
+++ b/watcher/poller.go
@@ -7,19 +7,21 @@ import (
 
 // Poll polls the queue for valid events given an interval (in seconds)
 func (pw *PathWatcher) Poll(interval int) {
-	ticker := time.NewTicker(time.Duration(interval) * time.Second)
-	for {
-		select {
-		case <-ticker.C:
-			log.Printf("Polling... - Queue Size: %d\n", pw.Queue.Size())
+	go func() {
+		ticker := time.NewTicker(time.Duration(interval) * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				log.Printf("Polling... - Queue Size: %d\n", pw.Queue.Size())
 
-			for hsh, ev := range pw.Queue.Queue {
-				timeDiff := ev.Timestamp.Sub(time.Now())
-				if timeDiff < (time.Duration(-interval) * time.Second) {
-					pw.Notify(ev.Path, ev.Operation)
-					pw.Queue.Remove(hsh)
+				for hsh, ev := range pw.Queue.Queue {
+					timeDiff := ev.Timestamp.Sub(time.Now())
+					if timeDiff < (time.Duration(-interval) * time.Second) {
+						pw.Notify(ev.Path, ev.Operation)
+						pw.Queue.Remove(hsh)
+					}
 				}
 			}
 		}
-	}
+	}()
 }

--- a/watcher/poller.go
+++ b/watcher/poller.go
@@ -1,0 +1,12 @@
+package watcher
+
+import "time"
+
+func Poll(interval int) {
+	ticker := time.NewTicker(interval * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+		}
+	}
+}

--- a/watcher/poller_test.go
+++ b/watcher/poller_test.go
@@ -1,0 +1,1 @@
+package watcher

--- a/watcher/poller_test.go
+++ b/watcher/poller_test.go
@@ -1,1 +1,35 @@
 package watcher
+
+import (
+	"testing"
+	"time"
+)
+
+var (
+	pollInterval = 1
+)
+
+func TestPoller(t *testing.T) {
+	t.Run("It successfully notifies of a new event", func(t *testing.T) {
+		pw := setupPathwatcher("/tmp")
+		pw.Poll(pollInterval)
+
+		ev := eventSetup(t)
+		pw.Queue.Add(*ev)
+
+		if pw.Queue.Size() != 1 {
+			t.Errorf("Queue size did not increase. want=%d, got=%d", 1, pw.Queue.Size())
+		}
+		<-time.After(3 * time.Second)
+
+		if pw.Queue.Size() != 0 {
+			t.Errorf("Queue size did not decrease. want=%d, got=%d", 0, pw.Queue.Size())
+		}
+	})
+}
+
+func setupPathwatcher(path string) *PathWatcher {
+	return &PathWatcher{
+		Queue: NewQueue(),
+	}
+}

--- a/watcher/queue.go
+++ b/watcher/queue.go
@@ -1,0 +1,35 @@
+package watcher
+
+import (
+	"crypto/md5"
+	"fmt"
+
+	"github.com/cian911/switchboard/event"
+)
+
+type Queue struct {
+	queue map[string]event.Event
+}
+
+func New() *Queue {
+	return &Queue{
+		queue: make(map[string]event.Event),
+	}
+}
+
+func (q *Queue) Add(hash string, ev event.Event) {
+	q.queue[hash] = ev
+}
+
+func (q *Queue) Retrieve(hash string) event.Event {
+	return q.queue[hash]
+}
+
+func (q *Queue) Remove(hash string) {
+	delete(q.queue, hash)
+}
+
+func generateHash(ev event.Event) string {
+	data := []byte(fmt.Sprintf("%s%s%s%s", ev.File, ev.Path, ev.Destination, ev.Ext))
+	return fmt.Sprintf("%x", md5.Sum(data))
+}

--- a/watcher/queue.go
+++ b/watcher/queue.go
@@ -7,29 +7,45 @@ import (
 	"github.com/cian911/switchboard/event"
 )
 
-type Queue struct {
-	queue map[string]event.Event
+// Q holds the Queue
+type Q struct {
+	Queue map[string]event.Event
 }
 
-func New() *Queue {
-	return &Queue{
-		queue: make(map[string]event.Event),
+// NewQueue create a new Q object
+func NewQueue() *Q {
+	return &Q{
+		Queue: make(map[string]event.Event),
 	}
 }
 
-func (q *Queue) Add(hash string, ev event.Event) {
-	q.queue[hash] = ev
+// Add adds to the queue
+func (q *Q) Add(ev event.Event) {
+	q.Queue[Hash(ev)] = ev
 }
 
-func (q *Queue) Retrieve(hash string) event.Event {
-	return q.queue[hash]
+// Retrieve get an item from the queue given a valid hash
+func (q *Q) Retrieve(hash string) event.Event {
+	return q.Queue[hash]
 }
 
-func (q *Queue) Remove(hash string) {
-	delete(q.queue, hash)
+// Remove removes an item from the queue
+func (q *Q) Remove(hash string) {
+	delete(q.Queue, hash)
 }
 
-func generateHash(ev event.Event) string {
-	data := []byte(fmt.Sprintf("%s%s%s%s", ev.File, ev.Path, ev.Destination, ev.Ext))
+// Size returns the size of the queue
+func (q *Q) Size() int {
+	return len(q.Queue)
+}
+
+// Empty returns a bool indicating if the queue is empty or not
+func (q *Q) Empty() bool {
+	return len(q.Queue) == 0
+}
+
+// Hash returns a md5 hash composed of an event File, Path, and Ext
+func Hash(ev event.Event) string {
+	data := []byte(fmt.Sprintf("%s%s%s", ev.File, ev.Path, ev.Ext))
 	return fmt.Sprintf("%x", md5.Sum(data))
 }

--- a/watcher/queue_test.go
+++ b/watcher/queue_test.go
@@ -1,0 +1,1 @@
+package watcher

--- a/watcher/queue_test.go
+++ b/watcher/queue_test.go
@@ -1,1 +1,48 @@
 package watcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cian911/switchboard/event"
+)
+
+func TestQueue(t *testing.T) {
+	t.Run("It adds one event to the queue", func(t *testing.T) {
+		q := setupQueue()
+		ev := testEvent()
+
+		q.Add(*ev)
+
+		if q.Size() != 1 {
+			t.Errorf("Could size did not increase as expected. want=%d, got=%d", 1, q.Size())
+		}
+	})
+
+	t.Run("It updates the event in the queue", func(t *testing.T) {
+		q := setupQueue()
+		ev := testEvent()
+
+		q.Add(*ev)
+		q.Add(*ev)
+		q.Add(*ev)
+
+		if q.Size() != 1 {
+			// Queue size should not increase
+			t.Errorf("Could size did not increase as expected. want=%d, got=%d", 1, q.Size())
+		}
+	})
+}
+
+func setupQueue() *Q {
+	return NewQueue()
+}
+
+func testEvent() *event.Event {
+	return &event.Event{
+		File:      "sample.txt",
+		Path:      "/var/sample.txt",
+		Ext:       ".txt",
+		Timestamp: time.Now(),
+	}
+}

--- a/watcher/queue_test.go
+++ b/watcher/queue_test.go
@@ -1,16 +1,23 @@
 package watcher
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cian911/switchboard/event"
 )
 
+var (
+	gFile = "sample.txt"
+	gPath = "/var/sample.txt"
+	gExt  = ".txt"
+)
+
 func TestQueue(t *testing.T) {
 	t.Run("It adds one event to the queue", func(t *testing.T) {
 		q := setupQueue()
-		ev := testEvent()
+		ev := testEvent(gFile, gPath, gExt)
 
 		q.Add(*ev)
 
@@ -21,7 +28,7 @@ func TestQueue(t *testing.T) {
 
 	t.Run("It updates the event in the queue", func(t *testing.T) {
 		q := setupQueue()
-		ev := testEvent()
+		ev := testEvent(gFile, gPath, gExt)
 
 		q.Add(*ev)
 		q.Add(*ev)
@@ -32,17 +39,56 @@ func TestQueue(t *testing.T) {
 			t.Errorf("Could size did not increase as expected. want=%d, got=%d", 1, q.Size())
 		}
 	})
+
+	t.Run("It gets an item from the queue", func(t *testing.T) {
+		q := setupQueue()
+		ev := testEvent(gFile, gPath, gExt)
+
+		hash := Hash(*ev)
+		q.Add(*ev)
+		e := q.Retrieve(hash)
+
+		if !reflect.DeepEqual(ev, &e) {
+			t.Errorf("Events are not the same. want=%v, got=%v", ev, e)
+		}
+	})
+
+	t.Run("It removes an item from the queue", func(t *testing.T) {
+		q := setupQueue()
+		ev := testEvent(gFile, gPath, gExt)
+
+		hash := Hash(*ev)
+		q.Add(*ev)
+		q.Remove(hash)
+
+		if q.Size() != 0 {
+			t.Errorf("Could size did not increase as expected. want=%d, got=%d", 0, q.Size())
+		}
+	})
+
+	t.Run("It returns a unique hash for a given event", func(t *testing.T) {
+		ev1 := testEvent(gFile, gPath, gExt)
+		ev2 := testEvent("sample2.txt", "/var/sample2.txt", ".txt")
+
+		h1 := Hash(*ev1)
+		h2 := Hash(*ev2)
+
+		if h1 == h2 {
+			t.Errorf("Hashes are the same when they shouldn't be. want=%s, got=%s", h1, h2)
+		}
+	})
 }
 
 func setupQueue() *Q {
 	return NewQueue()
 }
 
-func testEvent() *event.Event {
+func testEvent(file, path, ext string) *event.Event {
 	return &event.Event{
-		File:      "sample.txt",
-		Path:      "/var/sample.txt",
-		Ext:       ".txt",
+		File:      file,
+		Path:      path,
+		Ext:       ext,
 		Timestamp: time.Now(),
 	}
+
 }

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cian911/switchboard/event"
 	"github.com/cian911/switchboard/utils"
@@ -59,7 +60,6 @@ func TestWatcher(t *testing.T) {
 		pw, pc := setup(ev.Path, ev.Destination, ev.Ext)
 		pw.Register(&pc)
 		pw.Unregister(&pc)
-		t.Log("PATH: " + ev.Path + " FILE: " + ev.File)
 
 		for i := 1; i <= 3; i++ {
 			file := createTempFile(ev.Path, ".txt", t)
@@ -112,6 +112,7 @@ func eventSetup(t *testing.T) *event.Event {
 		Destination: t.TempDir(),
 		Ext:         ext,
 		Operation:   "CREATE",
+		Timestamp:   time.Now(),
 	}
 }
 


### PR DESCRIPTION
This PR adds a queue/polling system.

I encountered a bug wherein downloading files would trigger a `CREATE` event initially, but the operation would not have completed. This lead to the file being moved to the consumer destination, but being invalid.

This PR introduces a queue/polling system. Events will be added to a queue, wherein a poller will check every x number of seconds when the file was last modified. If the file was modified within the last x number of seconds, we will continue polling, otherwise, we can assume operation has completed, and the file is valid.

This does not obviously cover all scenarios, for example, you might be downloading a file and halfway through you may loose internet connectivity. In this instance, the file will be moved, and may very well be invalid. That being said, I believe this change will greatly improve switchboard compared to how it currently stands.