### PR TITLE
SWB: Add support for Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "*"
+
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -12,6 +16,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
       - name: Go Setup
         uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,21 @@ builds:
     - 5
     - 6
     - 7
-
+dockers:
+-
+  image_templates: ["ghcr.io/cian911/{{ .ProjectName }}:{{ .Version }}"]
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - --platform=linux/amd64
+  - --label=org.opencontainers.image.title={{ .ProjectName }}
+  - --label=org.opencontainers.image.description={{ .ProjectName }}
+  - --label=org.opencontainers.image.url=https://github.com/cian911/{{ .ProjectName }}
+  - --label=org.opencontainers.image.source=https://github.com/cian911/{{ .ProjectName }}
+  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+  - --label=org.opencontainers.image.revision={{ .FullCommit }}
+  - --label=org.opencontainers.image.licenses=GPL-3.0
 archives:
 -
   id: switchboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM bitnami/minideb:jessie
+
+ENV SWB_VERSION=0.2.4
+
+RUN apt-get update && apt-get install -y curl
+
+RUN curl -L https://github.com/Cian911/switchboard/releases/download/v${SWB_VERSION}/switchboard_${SWB_VERSION}_linux_64-bit.deb -o switchboard_${SWB_VERSION}_linux_64-bit.deb && \
+    dpkg -i switchboard_${SWB_VERSION}_linux_64-bit.deb && \
+    rm switchboard_${SWB_VERSION}_linux_64-bit.deb
+
+ENTRYPOINT ["switchboard"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
-FROM bitnami/minideb:jessie
+FROM alpine
 
-ENV SWB_VERSION=0.2.4
-
-RUN apt-get update && apt-get install -y curl
-
-RUN curl -L https://github.com/Cian911/switchboard/releases/download/v${SWB_VERSION}/switchboard_${SWB_VERSION}_linux_64-bit.deb -o switchboard_${SWB_VERSION}_linux_64-bit.deb && \
-    dpkg -i switchboard_${SWB_VERSION}_linux_64-bit.deb && \
-    rm switchboard_${SWB_VERSION}_linux_64-bit.deb
+COPY switchboard /usr/local/bin/switchboard
 
 ENTRYPOINT ["switchboard"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-arm run
+.PHONY: build build-arm build-debian run
 .PHONY: test-all test-watcher test-event test-utils test-cmd lint-all vet-all
 
 VERSION := test-build
@@ -7,6 +7,11 @@ BUILD_TIME := $$(date -u +"%Y%m%d.%H%M%S")
 
 build:
 	@go build \
+		-ldflags "-X main.Version=${VERSION} -X main.Build=${BUILD} -X main.BuildTime=${BUILD_TIME}" \
+		-o ./bin/switchboard ./cmd
+
+build-debian:
+	@GOOS=linux GOARCH=amd64 go build \
 		-ldflags "-X main.Version=${VERSION} -X main.Build=${BUILD} -X main.BuildTime=${BUILD_TIME}" \
 		-o ./bin/switchboard ./cmd
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,32 @@ brew install switchboard
 switchboard -h
 ```
 
+You can also upgrade the version of `switchboard` you already have installed by doing the following.
+
+```sh
+brew upgrade switchboard
+```
+
+##### Docker
+
+```sh
+docker pull ghcr.io/cian911/switchboard:${VERSION}
+
+docker run -d -v ${SRC} -v ${DEST} ghcr.io/cian911/switchboard:${VERSION} watch -h
+```
+
 ##### Go Install
 
 ```sh
-go install github.com/Cian911/switchboard@latest
+go install github.com/Cian911/switchboard@${VERSION}
 ```
 
 ##### Manually
 
-You can download the pre-compiled binary for your specific OS type from the [OSS releases page](https://github.com/Cian911/switchboard/releases). You will need to copy these and extract the binary, then move it to you local bin directory. See the example below.
+You can download the pre-compiled binary for your specific OS type from the [OSS releases page](https://github.com/Cian911/switchboard/releases). You will need to copy these and extract the binary, then move it to you local bin directory. See the example below for extracting a zipped version.
 
 ```sh
-wget https://github.com/Cian911/switchboard/releases/download/${VERSION}/${PACKAGE_NAME}
+curl https://github.com/Cian911/switchboard/releases/download/${VERSION}/${PACKAGE_NAME} -o ${PACKAGE_NAME}
 sudo tar -xvf ${PACKAGE_NAME} -C /usr/local/bin/
 sudo chmod +x /usr/local/bin/switchboard
 ```

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -49,6 +49,11 @@ func TestEvent(t *testing.T) {
 		if _, err := os.Stat(fmt.Sprintf("%s/%s", event.Destination, event.File)); errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("Failed to move from %s/%s to %s/%s: %v : %v", event.Path, event.File, event.Destination, event.File, err, *event)
 		}
+
+		// If the file still exists in the source directory, log an error
+		if _, err := os.Stat(fmt.Sprintf("%s/%s", event.Path, event.File)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Failed to delete file from %s/%s to %s/%s after Move: %v : %v", event.Path, event.File, event.Destination, event.File, err, *event)
+		}
 	})
 
 	t.Run("It moves file from one dir to another dir with valid destPath", func(t *testing.T) {
@@ -58,6 +63,11 @@ func TestEvent(t *testing.T) {
 		// If the file does not exist, log an error
 		if _, err := os.Stat(fmt.Sprintf("%s/%s", event.Destination, event.File)); errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("Failed to move from %s/%s to %s/%s: %v : %v", event.Path, event.File, event.Destination, event.File, err, *event)
+		}
+
+		// If the file still exists in the source directory, log an error
+		if _, err := os.Stat(fmt.Sprintf("%s/%s", event.Path, event.File)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Failed to delete file from %s/%s to %s/%s after Move: %v : %v", event.Path, event.File, event.Destination, event.File, err, *event)
 		}
 	})
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -51,6 +51,16 @@ func TestEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("It moves file from one dir to another dir with valid destPath", func(t *testing.T) {
+		event := eventSetup(t)
+		event.Move(fmt.Sprintf("%s/", event.Path), "")
+
+		// If the file does not exist, log an error
+		if _, err := os.Stat(fmt.Sprintf("%s/%s", event.Destination, event.File)); errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Failed to move from %s/%s to %s/%s: %v : %v", event.Path, event.File, event.Destination, event.File, err, *event)
+		}
+	})
+
 	t.Run("It does not move file from one dir to another dir", func(t *testing.T) {
 		event := eventSetup(t)
 		event.Destination = "/abcdefg"


### PR DESCRIPTION
### Description

This PR adds support for Docker.

### Changes

I have wanted to add a Docker example and use-case for the project. The original intention was to have switchboard run a a very lightweight alpine image, which would allow the user to add their own volume mounts (source & destination) and run the app. 

The problem however, is the `cross-device link` issue.

Under the hood in its current implementation, Switchboard just moves valid files to and from a source and destination directory using golangs `os.Rename()` function. The problem with doing this in a Docker context in the way described above, is that you are effectively creating two separate mount points and running `os.Rename()` which will fail as this calls the rename system call, which cannot rename files across devices, giving us our `cross-device link` error. 

One solution to avoid this is to change the `Move()` function and `os.Rename()` to create a temp file in the destination directory and _copy_ the file contents from the source. You can see an example of this in this PR.

This obviously has the drawback of temporarily duplicating the original file while the copy takes place before removing it after the operation has been completed, however I believe this is acceptable.